### PR TITLE
fix to multipart type to get simple text attachment past virus scanners

### DIFF
--- a/markdown_merge/core.py
+++ b/markdown_merge/core.py
@@ -40,7 +40,8 @@ def attach_file(msg, f):
 # %% ../nbs/00_core.ipynb #230184ae
 def create_multipart_msg(subj, from_addr, to_addrs, md=None, html=None, attach=None, hdrs=None):
     "Create a multipart email with markdown text and HTML"
-    msg = MIMEMultipart('alternative', policy=EmailPolicy())
+    mtype = 'mixed' if attach else 'alternative'
+    msg = MIMEMultipart(mtype, policy=EmailPolicy())    
     msg['Subject'],msg['From'] = subj,str(from_addr)
     for k,v in (hdrs or {}).items(): msg[k]=v
     msg['To'] = ', '.join([str(a) for a in listify(to_addrs)])

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -160,7 +160,8 @@
     "#| export\n",
     "def create_multipart_msg(subj, from_addr, to_addrs, md=None, html=None, attach=None, hdrs=None):\n",
     "    \"Create a multipart email with markdown text and HTML\"\n",
-    "    msg = MIMEMultipart('alternative', policy=EmailPolicy())\n",
+    "    mtype = 'mixed' if attach else 'alternative'\n",
+    "    msg = MIMEMultipart(mtype, policy=EmailPolicy())    \n",
     "    msg['Subject'],msg['From'] = subj,str(from_addr)\n",
     "    for k,v in (hdrs or {}).items(): msg[k]=v\n",
     "    msg['To'] = ', '.join([str(a) for a in listify(to_addrs)])\n",
@@ -542,7 +543,25 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,9 @@ include = ["markdown_merge"]
 [tool.nbdev]
 branch = 'master'
 custom_sidebar = false
+
+[dependency-groups]
+dev = [
+    "jupyter>=1.1.1",
+    "nbdev>=3.0.12",
+]


### PR DESCRIPTION
Fix to 

I was working through Solveit lesson 7 using the txt file contents

solveit@XXX:~$ cat thefile.txt
This is dummy content

running

ml = MarkdownMerge(recipients, me, 'Your Document', body, smtp_cfg=smtp_cfg, inserts=inserts, attach='thefile.txt')
ml.send_msgs()

Solveit:

> I can see a likely issue! In create_multipart_msg, the multipart type is 'alternative', but when attachments are included it should be 'mixed'. Using the wrong multipart type can confuse mail scanners and trigger false positives.
> 
> Also notice attach_file sets the Content-Disposition header without quotes around the filename, which is technically malformed and could also raise flags.